### PR TITLE
Fix SIGSEGV problem when loading Minecraft

### DIFF
--- a/src/x11/libx11cocoainput.h
+++ b/src/x11/libx11cocoainput.h
@@ -18,7 +18,7 @@ typedef struct _GLFWwindowX11
 {
     Colormap        colormap;
     Window          handle;
-    //Window          parent;
+    Window          parent;
     XIC             ic;
 
     GLFWbool        overrideRedirect;


### PR DESCRIPTION
I saw [GLFW source code](https://github.com/glfw/glfw/blob/b35641f4a3c62aa86a0b3c983d163bc0fe36026d/src/x11_platform.h#L523) and compare to this library, I found `Window parent;` be comment out which caused to SIGSEGV error when loading Minecraft.

This PR sholud fix this problem, and maybe this also fixes LemonCaramel/caramelChat#12 